### PR TITLE
fixed build failure on OS X El Capitan

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@ The current Tsunami protocol version is: v1.1
 Improvements and protocol version compliant new features
 are added in the cvs builds.
 
+build 20160123
+  - fixed build failure on OS X El Capitan
+   - added 'tsunami_' prefix to 'htonll' and 'ntohll' function name
+     'htonll' and 'ntohll' conflicted from OS X Yosemite
+
 build 20131230
    - do not inline got_block function - allows to compile on OS X Mavericks (thanks Matt Yanchyshyn for the suggestion) 
 

--- a/client/protocol.c
+++ b/client/protocol.c
@@ -209,7 +209,7 @@ int ttp_open_transfer(ttp_session_t *session, const char *remote_filename, const
     xfer->local_filename  = local_filename;
 
     /* read in the file length, block size, block count, and run epoch */
-    if (fread(&xfer->file_size,   8, 1, session->server) < 1) return warn("Could not read file size");         xfer->file_size   = ntohll(xfer->file_size);
+    if (fread(&xfer->file_size,   8, 1, session->server) < 1) return warn("Could not read file size");         xfer->file_size   = tsunami_ntohll(xfer->file_size);
     if (fread(&temp,              4, 1, session->server) < 1) return warn("Could not read block size");        if (htonl(temp) != param->block_size) return warn("Block size disagreement");
     if (fread(&xfer->block_count, 4, 1, session->server) < 1) return warn("Could not read number of blocks");  xfer->block_count = ntohl (xfer->block_count);
     if (fread(&xfer->epoch,       4, 1, session->server) < 1) return warn("Could not read run epoch");         xfer->epoch       = ntohl (xfer->epoch);

--- a/common/common.c
+++ b/common/common.c
@@ -141,12 +141,12 @@ u_int64_t get_usec_since(struct timeval *old_time)
 
 
 /*------------------------------------------------------------------------
- * u_int64_t htonll(u_int64_t value);
+ * u_int64_t tsunami_htonll(u_int64_t value);
  *
  * Converts the given 64-bit value in host byte order to network byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t htonll(u_int64_t value)
+u_int64_t tsunami_htonll(u_int64_t value)
 {
     static int necessary = -1;
 
@@ -186,14 +186,14 @@ char *make_transcript_filename(char *buffer, time_t epoch, const char *extension
 
 
 /*------------------------------------------------------------------------
- * u_int64_t ntohll(u_int64_t value);
+ * u_int64_t tsunami_ntohll(u_int64_t value);
  *
  * Converts the given 64-bit value in network byte order to host byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t ntohll(u_int64_t value)
+u_int64_t tsunami_ntohll(u_int64_t value)
 {
-    return htonll(value);
+    return tsunami_htonll(value);
 }
 
 

--- a/common/common_win32.c
+++ b/common/common_win32.c
@@ -185,12 +185,12 @@ u_int64_t get_usec_since(struct timeval *old_time)
 
 
 /*------------------------------------------------------------------------
- * u_int64_t htonll(u_int64_t value);
+ * u_int64_t tsunami_htonll(u_int64_t value);
  *
  * Converts the given 64-bit value in host byte order to network byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t htonll(u_int64_t value)
+u_int64_t tsunami_htonll(u_int64_t value)
 {
     static int necessary = -1;
 
@@ -230,14 +230,14 @@ char *make_transcript_filename(char *buffer, time_t epoch, const char *extension
 
 
 /*------------------------------------------------------------------------
- * u_int64_t ntohll(u_int64_t value);
+ * u_int64_t tsunami_ntohll(u_int64_t value);
  *
  * Converts the given 64-bit value in network byte order to host byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t ntohll(u_int64_t value)
+u_int64_t tsunami_ntohll(u_int64_t value)
 {
-    return htonll(value);
+    return tsunami_htonll(value);
 }
 
 

--- a/include/tsunami.h
+++ b/include/tsunami.h
@@ -138,9 +138,9 @@ extern char g_error[];  /* buffer for the most recent error string    */
 /* common.c */
 int        get_random_data         (u_char *buffer, size_t bytes);
 u_int64_t  get_usec_since          (struct timeval *old_time);
-u_int64_t  htonll                  (u_int64_t value);
+u_int64_t  tsunami_htonll          (u_int64_t value);
 char      *make_transcript_filename(char *buffer, time_t epoch, const char *extension);
-u_int64_t  ntohll                  (u_int64_t value);
+u_int64_t  tsunami_ntohll          (u_int64_t value);
 u_char    *prepare_proof           (u_char *buffer, size_t bytes, const u_char *secret, u_char *digest);
 int        read_line               (int fd, char *buffer, size_t buffer_length);
 int        fread_line              (FILE *f, char *buffer, size_t buffer_length);

--- a/mk5server/protocol.c
+++ b/mk5server/protocol.c
@@ -437,10 +437,10 @@ int ttp_open_transfer(ttp_session_t *session)
     param->epoch       = time(NULL);
 
     /* reply with the length, block size, number of blocks, and run epoch */
-    file_size   = htonll(param->file_size);    if (write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
-    block_size  = htonl (param->block_size);   if (write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
-    block_count = htonl (param->block_count);  if (write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
-    epoch       = htonl (param->epoch);        if (write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
+    file_size   = tsunami_htonll(param->file_size);  if (write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
+    block_size  = htonl (param->block_size);         if (write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
+    block_count = htonl (param->block_count);        if (write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
+    epoch       = htonl (param->epoch);              if (write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
 
     /*calculate and convert RTT to u_sec*/
     session->parameter->wait_u_sec=(ping_e.tv_sec - ping_s.tv_sec)*1000000+(ping_e.tv_usec-ping_s.tv_usec);

--- a/rtclient/protocol.c
+++ b/rtclient/protocol.c
@@ -209,7 +209,7 @@ int ttp_open_transfer(ttp_session_t *session, const char *remote_filename, const
     xfer->local_filename  = local_filename;
 
     /* read in the file length, block size, block count, and run epoch */
-    if (fread(&xfer->file_size,   8, 1, session->server) < 1) return warn("Could not read file size");         xfer->file_size   = ntohll(xfer->file_size);
+    if (fread(&xfer->file_size,   8, 1, session->server) < 1) return warn("Could not read file size");         xfer->file_size   = tsunami_ntohll(xfer->file_size);
     if (fread(&temp,              4, 1, session->server) < 1) return warn("Could not read block size");        if (htonl(temp) != param->block_size) return warn("Block size disagreement");
     if (fread(&xfer->block_count, 4, 1, session->server) < 1) return warn("Could not read number of blocks");  xfer->block_count = ntohl (xfer->block_count);
     if (fread(&xfer->epoch,       4, 1, session->server) < 1) return warn("Could not read run epoch");         xfer->epoch       = ntohl (xfer->epoch);

--- a/rtserver/protocol.c
+++ b/rtserver/protocol.c
@@ -576,10 +576,10 @@ int ttp_open_transfer(ttp_session_t *session)
     param->epoch       = time(NULL);
 
     /* reply with the length, block size, number of blocks, and run epoch */
-    file_size   = htonll(param->file_size);    if (full_write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
-    block_size  = htonl (param->block_size);   if (full_write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
-    block_count = htonl (param->block_count);  if (full_write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
-    epoch       = htonl (param->epoch);        if (full_write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
+    file_size   = tsunami_htonll(param->file_size);  if (full_write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
+    block_size  = htonl (param->block_size);         if (full_write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
+    block_count = htonl (param->block_count);        if (full_write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
+    epoch       = htonl (param->epoch);              if (full_write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
 
     /*calculate and convert RTT to u_sec*/
     session->parameter->wait_u_sec=(ping_e.tv_sec - ping_s.tv_sec)*1000000+(ping_e.tv_usec-ping_s.tv_usec);

--- a/server/protocol.c
+++ b/server/protocol.c
@@ -664,10 +664,10 @@ int ttp_open_transfer(ttp_session_t *session)
     param->epoch       = time(NULL);
 
     /* reply with the length, block size, number of blocks, and run epoch */
-    file_size   = htonll(param->file_size);    if (full_write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
-    block_size  = htonl (param->block_size);   if (full_write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
-    block_count = htonl (param->block_count);  if (full_write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
-    epoch       = htonl (param->epoch);        if (full_write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
+    file_size   = tsunami_htonll(param->file_size);  if (full_write(session->client_fd, &file_size,   8) < 0) return warn("Could not submit file size");
+    block_size  = htonl (param->block_size);         if (full_write(session->client_fd, &block_size,  4) < 0) return warn("Could not submit block size");
+    block_count = htonl (param->block_count);        if (full_write(session->client_fd, &block_count, 4) < 0) return warn("Could not submit block count");
+    epoch       = htonl (param->epoch);              if (full_write(session->client_fd, &epoch,       4) < 0) return warn("Could not submit run epoch");
 
     /*calculate and convert RTT to u_sec*/
     session->parameter->wait_u_sec=(ping_e.tv_sec - ping_s.tv_sec)*1000000+(ping_e.tv_usec-ping_s.tv_usec);


### PR DESCRIPTION
Can not build on OS X El Capitan causes 'htonll' and 'ntohll' conflicted from OS X Yosemite.
It should change some function name.

see also)
https://issues.apache.org/jira/browse/ZOOKEEPER-2049 https://github.com/apache/zookeeper/commit/be2037eec138dbc993d2365a2dbd336acb1d60db