### PR TITLE
Bugfix/linux builds

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -140,7 +140,8 @@ u_int64_t get_usec_since(struct timeval *old_time)
 }
 
 
-#ifndef _APPLE_
+
+#ifdef need_htonll
 /*------------------------------------------------------------------------
  * u_int64_t htonll(u_int64_t value);
  *
@@ -161,7 +162,7 @@ u_int64_t htonll(u_int64_t value)
     else
         return value;
 }
-#endif /* _APPLE_ */
+#endif
 
 
 /*------------------------------------------------------------------------
@@ -187,7 +188,7 @@ char *make_transcript_filename(char *buffer, time_t epoch, const char *extension
 }
 
 
-#ifndef _APPLE_
+#ifdef need_ntohll
 /*------------------------------------------------------------------------
  * u_int64_t ntohll(u_int64_t value);
  *
@@ -198,8 +199,7 @@ u_int64_t ntohll(u_int64_t value)
 {
     return htonll(value);
 }
-#endif /* _APPLE_ */
-
+#endif
 
 /*------------------------------------------------------------------------
  * u_char *prepare_proof(u_char *buffer, size_t bytes,

--- a/common/common.c
+++ b/common/common.c
@@ -140,13 +140,14 @@ u_int64_t get_usec_since(struct timeval *old_time)
 }
 
 
+#ifndef _APPLE_
 /*------------------------------------------------------------------------
  * u_int64_t htonll(u_int64_t value);
  *
  * Converts the given 64-bit value in host byte order to network byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t _htonll(u_int64_t value)
+u_int64_t htonll(u_int64_t value)
 {
     static int necessary = -1;
 
@@ -160,6 +161,7 @@ u_int64_t _htonll(u_int64_t value)
     else
         return value;
 }
+#endif /* _APPLE_ */
 
 
 /*------------------------------------------------------------------------
@@ -185,16 +187,18 @@ char *make_transcript_filename(char *buffer, time_t epoch, const char *extension
 }
 
 
+#ifndef _APPLE_
 /*------------------------------------------------------------------------
  * u_int64_t ntohll(u_int64_t value);
  *
  * Converts the given 64-bit value in network byte order to host byte
  * order and returns it.
  *------------------------------------------------------------------------*/
-u_int64_t _ntohll(u_int64_t value)
+u_int64_t ntohll(u_int64_t value)
 {
     return htonll(value);
 }
+#endif /* _APPLE_ */
 
 
 /*------------------------------------------------------------------------

--- a/include/tsunami.h
+++ b/include/tsunami.h
@@ -72,6 +72,11 @@
 #include <sys/time.h>   /* for struct timeval          */
 #include <stdio.h>      /* for NULL, FILE *, etc.      */
 
+// Needed to detect OSX versions greater than 10.10
+#ifdef __APPLE__
+#include <Availabilty.h>
+#endif 
+
 #include "tsunami-cvs-buildnr.h"   /* for the current TSUNAMI_CVS_BUILDNR */
 
 
@@ -88,6 +93,14 @@
 #define tv_diff_usec(newer,older) ((newer.tv_sec-older.tv_sec)*1e6 + (newer.tv_usec-older.tv_usec))
 
 typedef unsigned long long ull_t;
+
+#ifndef __APPLE__
+#define need_htonll 1
+#define need_ntohll 1
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED < 1090
+#define need_htonll 1
+#define need_ntohll 1
+#endif
 
 /*------------------------------------------------------------------------
  * Global constants.
@@ -138,10 +151,12 @@ extern char g_error[];  /* buffer for the most recent error string    */
 /* common.c */
 int        get_random_data         (u_char *buffer, size_t bytes);
 u_int64_t  get_usec_since          (struct timeval *old_time);
-#ifndef _APPLE_
+#ifdef need_htonll
 u_int64_t  htonll                  (u_int64_t value);
+#endif
+#ifdef need_ntohll
 u_int64_t  ntohll                  (u_int64_t value);
-#endif /* _APPLE_ */
+#endif
 char      *make_transcript_filename(char *buffer, time_t epoch, const char *extension);
 u_char    *prepare_proof           (u_char *buffer, size_t bytes, const u_char *secret, u_char *digest);
 int        read_line               (int fd, char *buffer, size_t buffer_length);

--- a/include/tsunami.h
+++ b/include/tsunami.h
@@ -97,7 +97,7 @@ typedef unsigned long long ull_t;
 #ifndef __APPLE__
 #define need_htonll 1
 #define need_ntohll 1
-#elif __MAC_OS_X_VERSION_MAX_ALLOWED < 1090
+#elif __MAC_OS_X_VERSION_MAX_ALLOWED < 101000
 #define need_htonll 1
 #define need_ntohll 1
 #endif

--- a/include/tsunami.h
+++ b/include/tsunami.h
@@ -138,9 +138,11 @@ extern char g_error[];  /* buffer for the most recent error string    */
 /* common.c */
 int        get_random_data         (u_char *buffer, size_t bytes);
 u_int64_t  get_usec_since          (struct timeval *old_time);
-u_int64_t  _htonll                  (u_int64_t value);
+#ifndef _APPLE_
+u_int64_t  htonll                  (u_int64_t value);
+u_int64_t  ntohll                  (u_int64_t value);
+#endif /* _APPLE_ */
 char      *make_transcript_filename(char *buffer, time_t epoch, const char *extension);
-u_int64_t  _ntohll                  (u_int64_t value);
 u_char    *prepare_proof           (u_char *buffer, size_t bytes, const u_char *secret, u_char *digest);
 int        read_line               (int fd, char *buffer, size_t buffer_length);
 int        fread_line              (FILE *f, char *buffer, size_t buffer_length);


### PR DESCRIPTION
When the ntohll() and htonll() routines in common/common.c were changed so not to conflict with Yosemite's version of the routines, the Linux compiles stopped building. This patch allows Linux builds to continue as before and should allow OSX to build. Also added directives to "in theory" detect when being built by an OSX earlier than Yosemite. 